### PR TITLE
Bugfix: build target when version.h changed. 

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,9 +6,8 @@ all: $(TARGET)
 $(TARGET): $(OBJECTS)
 	$(CC) -o $@ $^
 
+main.o: | new_header
 main.o: version.h
-
-version.h: new_header
 
 new_header:
 	@sed -e "s#<version>#$$(git describe --dirty --always)#g" < version.h.in > version.h.tmp


### PR DESCRIPTION
Without this fix, when version changed only version.h update, target rebuild needs a second `make`.
